### PR TITLE
mandos: init at 1.8.14

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -944,6 +944,7 @@
   ./services/security/hockeypuck.nix
   ./services/security/hologram-server.nix
   ./services/security/hologram-agent.nix
+  ./services/security/mandos/mandos.nix
   ./services/security/munge.nix
   ./services/security/nginx-sso.nix
   ./services/security/oauth2_proxy.nix

--- a/nixos/modules/services/security/mandos/mandos.nix
+++ b/nixos/modules/services/security/mandos/mandos.nix
@@ -1,0 +1,286 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.mandos;
+
+  clientDefaults = {
+    "DEFAULT" = {
+      "approval_delay" = "PT0S";
+      "approval_duration" = 1;
+      "approved_by_default" = true;
+      "checker" = "fping -q -- %%(host)s";
+      "extended_timeout" = "PT15M";
+      "interval" = "PT2M";
+      "timeout" = "PT5M";
+      "enabled" = true;
+    };
+  };
+
+  mandosConfText = generators.toINI { } {
+    "DEFAULT" = {
+      "interface" = cfg.conf.interface;
+      "address" = cfg.conf.address;
+      "port" = cfg.conf.port;
+      "debug" = cfg.conf.debug;
+      "priority" = cfg.conf.priority;
+      "servicename" = cfg.servicename;
+      "use_dbus" = cfg.conf.use_dbus;
+      "use_ipv6" = cfg.conf.use_ipv6;
+      "restore" = cfg.conf.restore;
+      "statedir" = cfg.conf.statedir;
+      "socket" = cfg.conf.socket;
+    };
+  };
+
+  mandosConfFile = pkgs.writeText "mandos.conf" ''
+    ${mandosConfText}
+
+    ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
+  '';
+
+  mandosClientText = generators.toINI { } cfg.clients;
+
+  mandosClientFile = pkgs.writeText "mandos-clients.conf" mandosClientText;
+
+in
+{
+  options = {
+    services.mandos.conf = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Enable the mandos-server service.";
+        };
+
+        extraConfig = mkOption {
+          type = with types; nullOr lines;
+          default = null;
+          description = "Extra config options as raw text lines";
+          example = ''
+            address = 127.0.0.1
+            interface = eth0
+          '';
+        };
+
+        extraArgs = mkOption {
+          type = with types; nullOr lines;
+          default = null;
+          description = "Extra command-line options as raw text lines";
+          example = ''
+            --no-zeroconf
+            --foreground
+          '';
+        };
+
+        package = mkOption {
+          type = types.package;
+          default = pkgs.mandos;
+          defaultText = literalExpression "pkgs.mandos";
+          description = "Which mandos-server package to use.";
+        };
+
+        interface = mkOption {
+          type = with types; nullOr string;
+          default = null;
+          description = ''
+            If this is specified, the server will only announce the service and listen to requests on the specified network interface.
+
+            Default is to use all available interfaces.";
+          '';
+        };
+
+        address = mkOption {
+          type = types.string;
+          default = "0.0.0.0";
+          description = ''
+            If this option is used, the server will only listen to the specified IPv6 address.
+
+            If a link-local address is specified, an interface should be set, since a link-local address is only valid on a single interface.
+
+            By default, the server will listen to all available addresses.
+
+            If set, this must normally be an IPv6 address; an IPv4 address can only be specified using IPv4-mapped IPv6 address syntax: “::FFFF:192.0.2.3”. (Only if use_ipv6 is disabled must this be an IPv4 address.)
+          '';
+        };
+
+        port = mkOption {
+          type = with types; nullOr int;
+          default = null;
+          description = ''
+            If this option is used, the server will bind to that port.
+
+            By default, the server will listen to an arbitrary port given by the operating system.
+          '';
+        };
+
+        debug = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            If the server is run in debug mode, it will run in the foreground and print a lot of debugging information.
+
+            The default is to not run in debug mode.
+          '';
+        };
+
+        priority = mkOption {
+          type = types.string;
+          default = "SECURE128​:!CTYPE-X.509​:+CTYPE-RAWPK​:!RSA​:!VERS-ALL​:+VERS-TLS1.3​:%PROFILE_ULTRA";
+          description = ''
+            GnuTLS priority string for the TLS handshake.
+
+            The default is “SECURE128​:!CTYPE-X.509​:+CTYPE-RAWPK​:!RSA​:!VERS-ALL​:+VERS-TLS1.3​:%PROFILE_ULTRA” when using raw public keys in TLS, and “SECURE256​:!CTYPE-X.509​:+CTYPE-OPENPGP​:!RSA​:+SIGN-DSA-SHA256” when using OpenPGP keys in TLS.
+
+            See gnutls_priority_init(3) for the syntax. Warning: changing this may make the TLS handshake fail, making server-client communication impossible. Changing this option may also make the network traffic decryptable by an attacker.
+          '';
+        };
+
+        servicename = mkOption {
+          type = types.string;
+          default = "Mandos";
+          description = ''
+            Zeroconf service name.
+
+            The default is “Mandos”.
+
+            This only needs to be changed if for some reason is would be necessary to run more than one server on the same host. This would not normally be useful. If there are name collisions on the same network, the newer server will automatically rename itself to “Mandos #2”, and so on; therefore, this option is not needed in that case.
+          '';
+        };
+
+        use_dbus = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            This option controls whether the server will provide a D-Bus system bus interface.
+
+            The default is to provide such an interface.
+          '';
+        };
+
+        use_ipv6 = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            This option controls whether the server will use IPv6 sockets and addresses.
+
+            The default is to use IPv6.
+
+            This option should never normally be turned off, even in IPv4-only environments. This is because mandos-client(8mandos) will normally use IPv6 link-local addresses, and will not be able to find or connect to the server if this option is turned off. Only advanced users should consider changing this option.
+          '';
+        };
+
+        restore = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            This option controls whether the server will restore its state from the last time it ran.
+
+            Default is to restore last state.
+          '';
+        };
+
+        statedir = mkOption {
+          type = types.path;
+          default = "/var/lib/mandos";
+          description = ''
+            Directory to save (and restore) state in.
+
+            Default is “/var/lib/mandos”.
+          '';
+        };
+
+        socket = mkOption {
+          type = with types; nullOr int;
+          default = null;
+          description = ''
+            If this option is used, the server will not create a new network socket, but will instead use the supplied file descriptor.
+
+            By default, the server will create a new network socket.
+          '';
+        };
+    };
+
+    services.mandos.clients = mkOption {
+      type = with types; attrsOf attrs;
+      default = clientDefaults;
+      example = literalExpression ''
+        "DEFAULT" = {
+          "extended_timeout" = "PT15M";
+          "interval" = "PT1M";
+          "timeout" = "PT10M";
+          "enabled" = false;
+        };
+
+        "foo" = {
+          "key_id" = "788cd77115cd0bb7b2d5e0ae8496f6b48149d5e712c652076b1fd2d957ef7c1f";
+          "fingerprint" =  "7788 2722 5BA7 DE53 9C5A  7CFA 59CF F7CD BD9A 5920";
+          "secret" =\'\'
+                  hQIOA6QdEjBs2L/HEAf/TCyrDe5Xnm9esa+Pb/vWF9CUqfn4srzVgSu234
+                  REJMVv7lBSrPE2132Lmd2gqF1HeLKDJRSVxJpt6xoWOChGHg+TMyXDxK+N
+                  Xl89vGvdU1XfhKkVm9MDLOgT5ECDPysDGHFPDhqHOSu3Kaw2DWMV/iH9vz
+                  3Z20erVNbdcvyBnuojcoWO/6yfB5EQO0BXp7kcyy00USA3CjD5FGZdoQGI
+                  Tb8A/ar0tVA5crSQmaSotm6KmNLhrFnZ5BxX+TiE+eTUTqSloWRY6VAvqW
+                  QHC7OASxK5E6RXPBuFH5IohUA2Qbk5AHt99pYvsIPX88j2rWauOokoiKZo
+                  t/9leJ8VxO5l3wf/U64IH8bkPIoWmWZfd/nqh4uwGNbCgKMyT+AnvH7kMJ
+                  3i7DivfWl2mKLV0PyPHUNva0VQxX6yYjcOhj1R6fCr/at8/NSLe2OhLchz
+                  dC+Ls9h+kvJXgF8Sisv+Wk/1RadPLFmraRlqvJwt6Ww21LpiXqXHV2mIgq
+                  WnR98YgSvUi3TJHrUQiNc9YyBzuRo0AjgG2C9qiE3FM+Y28+iQ/sR3+bFs
+                  zYuZKVTObqiIslwXu7imO0cvvFRgJF/6u3HNFQ4LUTGhiM3FQmC6NNlF3/
+                  vJM2hwRDMcJqDd54Twx90Wh+tYz0z7QMsK4ANXWHHWHR0JchnLWmenzbtW
+                  5MHdW9AYsNJZAQSOpirE4Xi31CSlWAi9KV+cUCmWF5zOFy1x23P6PjdaRm
+                  4T2zw4dxS5NswXWU0sVEXxjs6PYxuIiCTL7vdpx8QjBkrPWDrAbcMyBr2O
+                  QlnHIvPzEArRQLo=
+          \'\';
+          "host" = "foo.example.org";
+          "interval" = "PT1M";
+        };
+
+        "bar" = {
+          "key_id" = "F90C7A81D72D1EA69A51031A91FF8885F36C8B46D155C8C58709A4C99AE9E361";
+          "fingerprint" = "3e393aeaefb84c7e89e2f547b3a107558fca3a27";
+          "secfile" = /"etc/mandos/bar-secret";
+          "timeout" = "PT15M";
+          "approved_by_default" = "False";
+          "approval_delay" = "PT30S";
+        };
+      '';
+      description = "mandos.clients.conf configuration as nix attributes. Client configuration documentation is available here <https://www.recompile.se/mandos/man/mandos-clients.conf.5> or in the mandos-clients.conf.5 manual page.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc = {
+      "mandos/mandos.conf".source = mandosConfFile;
+      "mandos/mandos-client.conf".source = mandosClientFile;
+      "dbus-1/system.d/mandos.conf".source = "${cfg.conf.package}/etc/dbus-1/systemd.d/mandos.conf";
+      "default/mandos/default-mandos".source = "${cfg.conf.package}/etc/default/mandos/default-mandos";
+      "init.d/mandos".source = "${cfg.conf.package}/etc/init.d/mandos";
+    };
+
+    systemd.services.mandos = {
+      description = "Server of encrypted passwords to Mandos clients";
+      documentation = "man:intro(8mandos) man:mandos(8)";
+      ## If the server is configured to listen to a specific IP or network
+      ## interface, it may be necessary to change "network.target" to
+      ## "network-online.target".
+      after = [ "network.target" "avahi-daemon.service" ];
+      requisite = [ "avahi-daemon.service" ];
+      serviceConfig = {
+        busName = "se.recompile.Mandos";
+        environmentFile = "${cfg.conf.package}/etc/default/mandos/default-mandos";
+        execStart = "${cfg.conf.package}/sbin/mandos --foreground --configdir /etc/mandos ${concatStringsSep " " cfg.conf.extraArgs}";
+        restart = "always";
+        killMode = "mixed";
+        privateTmp = "yes";
+        privateDevices = "yes";
+        protectSystem = "full";
+        protectHome = "yes";
+        capabilityBoundingSet = "CAP_KILL CAP_SETGID CAP_SETUID CAP_DAC_OVERRIDE CAP_NET_RAW";
+        protectKernelTunables = "yes";
+        protectControlGroups = "yes";
+      };
+    };
+  };
+}

--- a/pkgs/servers/mandos/default.nix
+++ b/pkgs/servers/mandos/default.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  docbook_xml_dtd_45,
+  docbook-xsl-nons,
+  gpgme,
+  glib,
+  gnutls,
+  libxslt,
+  pkg-config,
+  libnl,
+  avahi,
+  systemd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mandos";
+  version = "1.8.14";
+
+  src = fetchzip {
+    url = "https://ftp.recompile.se/pub/mandos/mandos_${version}.orig.tar.gz";
+    sha256 = "1nywcn9w5k1f1pndyxnrhhwqpzd8yla895x3jnbzrsfvj6wzsh1r";
+  };
+
+  nativeBuildInputs = [
+    docbook_xml_dtd_45
+    docbook-xsl-nons
+    gpgme
+    glib
+    gnutls
+    libxslt
+    pkg-config
+    libnl
+  ];
+
+  buildInputs = [ avahi systemd ];
+
+  doCheck = false;
+
+  patchPhase = ''
+    sed -i 's@/usr/share/xml/docbook/stylesheet/nwalsh/xhtml/docbook.xsl@${docbook-xsl-nons}/share/xml/docbook-xsl-nons/xhtml/docbook.xsl@g' ./Makefile
+    sed -i 's@/usr/share/xml/docbook/stylesheet/nwalsh/manpages/docbook.xsl@${docbook-xsl-nons}/share/xml/docbook-xsl-nons/manpages/docbook.xsl@g' ./Makefile
+  '';
+
+  buildPhase = ''
+    # do nothing
+    echo
+  '';
+
+  preInstall = ''
+    mkdir -p \
+      $out/var/lib/mandos \
+      $out/usr/sbin \
+      $out/etc/dbus-1/system.d \
+      $out/etc/init.d/ \
+      $out/etc/default/mandos \
+      $out/usr/share/man/man8 \
+      $out/usr/share/man/man5
+  '';
+
+  postInstall = ''
+    # this directory isn't needed, clean up
+    rm -rf $out/var
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    set -x
+    ls -R $out
+    make install-server DESTDIR=$out
+    set +x
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A system for allowing servers with encrypted root file systems to reboot unattended and/or remotely.";
+    longDescription = ''
+      Mandos is a system for allowing servers with encrypted root file systems to reboot unattended and/or remotely. See the manual <https://www.recompile.se/mandos#The_Manual_Pages> for more information, including an FAQ list.
+
+      Mandos is Free Software, licensed using the GNU General Public License v3 or later.
+
+      (The Halls of Mandos is, in the fictional world of J. R. R. Tolkien, where the spirits of dead elves would go to be judged and possibly reincarnated. Similarly, the Mandos system allows “dead” servers to request reincarnation, which can be either denied or granted by the Mandos server.)
+    '';
+    homepage = "https://www.recompile.se/mandos";
+    downloadPage = "https://www.recompile.se/mandos";
+    license = with licenses; gpl3Plus;
+    maintainers = with maintainers; [ nukaduka ];
+    platforms = with platforms; linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21105,6 +21105,8 @@ with pkgs;
 
   maker-panel = callPackage ../tools/misc/maker-panel { };
 
+  mandos = callPackage ../servers/mandos { };
+
   mastodon = callPackage ../servers/mastodon { };
 
   materialize = callPackage ../servers/sql/materialize {


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
